### PR TITLE
Fix server startup message

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,11 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 'use strict';
-// change
 const express = require('express');
 
 // Constants
-const PORT = 3000;
+const PORT = process.env.PORT || 3000;
 const HOST = '0.0.0.0';
 
 // App
@@ -17,5 +16,6 @@ app.get('/', (req, res) => {
 	res.send('Hello remote world!\n');
 });
 
-app.listen(PORT, HOST);
-console.log(`Running on http://${HOST}:${PORT}`);
+app.listen(PORT, HOST, () => {
+  console.log(`Running on http://${HOST}:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- use `process.env.PORT` to allow port override
- log server startup in `listen` callback
- clean up leftover comment

## Testing
- `node --check server.js`

------
https://chatgpt.com/codex/tasks/task_e_68443e3eb5008321bc8378e0f283b84e