### PR TITLE
Add mocha test scaffold

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,14 @@
   "main": "server.js",
   "private": true,
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "mocha"
   },
   "dependencies": {
     "express": "^4.16.1"
+  },
+  "devDependencies": {
+    "mocha": "^10.2.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -17,5 +17,7 @@ app.get('/', (req, res) => {
 	res.send('Hello remote world!\n');
 });
 
-app.listen(PORT, HOST);
+const server = app.listen(PORT, HOST);
 console.log(`Running on http://${HOST}:${PORT}`);
+
+module.exports = server;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const request = require('supertest');
+let server;
+
+describe('GET /', function() {
+  before(function() {
+    server = require('../server');
+  });
+
+  after(function(done) {
+    server.close(done);
+  });
+
+  it('responds with Hello remote world!', function(done) {
+    request(server)
+      .get('/')
+      .expect(200)
+      .expect('Hello remote world!\n', done);
+  });
+});


### PR DESCRIPTION
## Summary
- export the running server for tests
- add mocha and supertest dev dependencies
- create a basic server test

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443f8f659c83218359816180242112